### PR TITLE
Updated intro text for encrypt and verify

### DIFF
--- a/app/src/main/java/net/opendasharchive/openarchive/features/core/dialog/BaseDialog.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/features/core/dialog/BaseDialog.kt
@@ -241,6 +241,7 @@ fun DialogHost(dialogStateManager: DialogStateManager) {
         BaseDialog(
             onDismiss = {
                 dialogStateManager.dismissDialog()
+                config.onDismissAction?.invoke()
             },
             icon = config.icon,
             iconColor = config.iconColor,

--- a/app/src/main/java/net/opendasharchive/openarchive/features/core/dialog/DialogConfigBuilder.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/features/core/dialog/DialogConfigBuilder.kt
@@ -111,6 +111,10 @@ class DialogBuilder {
             .build(defaultText = defaultDestructiveText())
     }
 
+    fun onDismissAction(block: () -> Unit) {
+        _onDismissAction = block
+    }
+
     // Default texts based on type.
     private fun defaultPositiveTextFor(type: DialogType): UiText = when (type) {
         DialogType.Success -> UiText.StringResource(R.string.lbl_ok)
@@ -211,6 +215,7 @@ class DialogBuilder {
             positiveButton = _positiveButton, //?: ButtonData(defaultPositiveTextFor(type)),
             neutralButton = _neutralButton,
             destructiveButton = _destructiveButton,
+            onDismissAction = _onDismissAction,
             showCheckbox = showCheckbox,
             checkboxText = checkboxText,
             onCheckboxChanged = onCheckboxChanged,
@@ -267,6 +272,7 @@ fun DialogStateManager.showSuccessDialog(
     @StringRes positiveButtonText: Int? = null,
     icon: UiImage? = null,
     onDone: () -> Unit = {},
+    onDismissed: () -> Unit = {}
 ) {
     val resourceProvider = this.requireResourceProvider()
 
@@ -279,6 +285,9 @@ fun DialogStateManager.showSuccessDialog(
         positiveButton {
             text = UiText.StringResource(positiveButtonText ?: R.string.lbl_got_it)
             action = onDone
+        }
+        onDismissAction {
+            onDismissed()
         }
     }
 }

--- a/app/src/main/java/net/opendasharchive/openarchive/features/folders/BrowseFoldersFragment.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/features/folders/BrowseFoldersFragment.kt
@@ -92,6 +92,10 @@ class BrowseFoldersFragment : BaseFragment(), MenuProvider {
             positiveButtonText = R.string.label_got_it,
             onDone = {
                 navigateBackWithResult(projectId)
+            },
+            onDismissed = {
+                // If the dialog is dismissed, we still want to navigate back
+                navigateBackWithResult(projectId)
             }
         )
     }

--- a/app/src/main/java/net/opendasharchive/openarchive/features/main/adapters/MainMediaAdapter.kt
+++ b/app/src/main/java/net/opendasharchive/openarchive/features/main/adapters/MainMediaAdapter.kt
@@ -231,38 +231,38 @@ class MainMediaAdapter(
         if (pos < 0 || pos >= media.size) return
 
         val item = media[pos]
-        var undone = false
+//        var undone = false
 
-        val snackbar =
-            Snackbar.make(recyclerView, R.string.confirm_remove_media, Snackbar.LENGTH_LONG)
-        snackbar.setAction(R.string.undo) { _ ->
-            undone = true
-            media.add(pos, item)
+//        val snackbar =
+//            Snackbar.make(recyclerView, R.string.confirm_remove_media, Snackbar.LENGTH_INDEFINITE)
+//        snackbar.setAction(R.string.undo) { _ ->
+//            undone = true
+//            media.add(pos, item)
+//
+//            notifyItemInserted(pos)
+//        }
+//
+//        snackbar.addCallback(object : Snackbar.Callback() {
+//            override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
+//                if (!undone) {
+//                    val collection = item.collection
+//
+//                    // Delete collection along with the item, if the collection
+//                    // would become empty.
+//                    if ((collection?.size ?: 0) < 2) {
+//                        collection?.delete()
+//                    } else {
+//                        item.delete()
+//                    }
+//
+//                    BroadcastManager.postDelete(recyclerView.context, item.id)
+//                }
+//
+//                super.onDismissed(transientBottomBar, event)
+//            }
+//        })
 
-            notifyItemInserted(pos)
-        }
-
-        snackbar.addCallback(object : Snackbar.Callback() {
-            override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
-                if (!undone) {
-                    val collection = item.collection
-
-                    // Delete collection along with the item, if the collection
-                    // would become empty.
-                    if ((collection?.size ?: 0) < 2) {
-                        collection?.delete()
-                    } else {
-                        item.delete()
-                    }
-
-                    BroadcastManager.postDelete(recyclerView.context, item.id)
-                }
-
-                super.onDismissed(transientBottomBar, event)
-            }
-        })
-
-        snackbar.show()
+        //snackbar.show()
 
         removeItem(item.id)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -313,12 +313,12 @@
     <string name="intro_text_verify"><![CDATA[Authenticate and verify your media with sha256 hashes and <a href=\"%1$s\"><u>ProofMode</u></a>.]]></string>
     <string name="intro_link_verify" translatable="false">https://proofmode.org</string>
     <string name="intro_text_encrypt_old">Automatically upload over TLS (Transport Layer Security) and use Orbot to protect your media in transit over the Tor network.</string>
-    <string name="intro_text_encrypt" translatable="false"><![CDATA[<b><i>Save</i></b> always uploads over TLS (Transport Layer Security) to protect your media in transit.<br>To further enhance security, enable <a href=\"%1$s\"><u>Tor</u></a> to prevent interception of your media from your phone to the server.]]></string>
+    <string name="intro_text_encrypt" translatable="false"><![CDATA[<b><i>Save</i></b> always uploads over TLS (Transport Layer Security) to protect your media in transit.<br>To further enhance security, enable <a href=\"%1$s\"><u>Orbot</u></a> to prevent interception of your media from your phone to the server.]]></string>
 <!--    <string name="intro_text_encrypt">-->
 <!--        &lt;b&gt;&lt;i&gt;Save&lt;/i&gt;&lt;/b&gt; always uploads over TLS (Transport Layer Security) to protect your media in transit.&lt;br&gt;-->
 <!--        To further enhance security, enable &lt;a href="%1$s" style="text-decoration: underline;"&gt;Tor&lt;/a&gt; to prevent interception of your media from your phone to the server.-->
 <!--    </string>-->
-    <string name="intro_link_encrypt" translatable="false">https://www.torproject.org</string>
+    <string name="intro_link_encrypt" translatable="false">https://orbot.app/</string>
 
     <string name="next">Next</string>
     <string name="done">Done</string>


### PR DESCRIPTION
- In the verify step, changed the link from the ProofMode github to proofmode.org
- In the encrypt step, changed "Tor" to "Orbot", and updated the link to orbot.app

Added onDismiss action to dialogs

When a dialog is dismissed by tapping outside of it, an optional action can now be triggered. This is used in the "Project created" dialog to ensure navigation still occurs.

Removed Snackbar for media deletion

The Snackbar confirming media deletion has been removed as per ticket #673. Media items are now deleted immediately.