### PR TITLE
fix: update upload description for internet archive to specify free public server

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,7 +59,7 @@ android {
         applicationId = "net.opendasharchive.openarchive"
         minSdk = 29
         targetSdk = 36
-        versionCode = 30015
+        versionCode = 30016
         versionName = "4.0.2"
         multiDexEnabled = true
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -196,7 +196,7 @@
     <string name="to_get_started_more_hint">You can add multiple private servers and\none IA account at any time.</string>
     <string name="in_the_side_menu_you_can_add_another_server_and_connect_to_multiple_servers">In the side menu, you can add another server and connect to multiple servers</string>
     <string name="send_directly_to_a_private_server">Connect to a secure WebDAV server</string>
-    <string name="upload_to_the_internet_archive">Connect to a free public or paid private server</string>
+    <string name="upload_to_the_internet_archive">Connect to a free public server</string>
     <string name="save_connects_to_webdav_compatible_servers_only_such_as_nextcloud_and_owncloud">Connect to a WebDAV-compatible servers, e.g. Nexcloud and ownCloud.</string>
     <string name="action_next">Next</string>
     <string name="action_done">Done</string>


### PR DESCRIPTION
This pull request contains a version bump and a minor update to user-facing text. The version code for the Android app has been incremented, and the description for connecting to the Internet Archive has been clarified to indicate only free public servers.

Versioning:

* Incremented the `versionCode` in `app/build.gradle.kts` from 30015 to 30016 to prepare for a new release.

User interface text:

* Updated the `upload_to_the_internet_archive` string in `strings.xml` to clarify that it connects to a free public server, removing mention of paid private servers.